### PR TITLE
fixes for gemstone

### DIFF
--- a/src/Material-Design-Lite-Components.package/WAHtmlCanvas.extension/instance/mdlChipContact..st
+++ b/src/Material-Design-Lite-Components.package/WAHtmlCanvas.extension/instance/mdlChipContact..st
@@ -1,5 +1,5 @@
 *Material-Design-Lite-Components
-mdlChipContact: aBlock.
+mdlChipContact: aBlock
 	^ self mdlChipContact
 		with: aBlock;
 		yourself

--- a/src/Material-Design-Lite-Extensions.package/MDLPanelSwitcherButton.class/instance/jsOnComplete.st
+++ b/src/Material-Design-Lite-Extensions.package/MDLPanelSwitcherButton.class/instance/jsOnComplete.st
@@ -1,3 +1,3 @@
 javascript
 jsOnComplete
-	^ self onCompleteJs ifNotNil: #js
+	^  self onCompleteJs ifNotNil: [ :script | script js ]


### PR DESCRIPTION
GemStone's compiler cannot handle . characters at the end of method parameter lists